### PR TITLE
Replacing assertion libraries: Hamcrest by AsseJ

### DIFF
--- a/jnosql-cassandra-extension/src/test/java/org/eclipse/jnosql/mapping/cassandra/column/CassandraColumnEntityConverterTest.java
+++ b/jnosql-cassandra-extension/src/test/java/org/eclipse/jnosql/mapping/cassandra/column/CassandraColumnEntityConverterTest.java
@@ -18,6 +18,7 @@ import jakarta.nosql.TypeReference;
 import jakarta.nosql.Value;
 import jakarta.nosql.column.Column;
 import jakarta.nosql.column.ColumnEntity;
+import org.assertj.core.api.Assertions;
 import org.eclipse.jnosql.mapping.cassandra.column.model.Actor;
 import org.eclipse.jnosql.mapping.cassandra.column.model.AppointmentBook;
 import org.eclipse.jnosql.mapping.cassandra.column.model.Artist;
@@ -50,8 +51,7 @@ import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -104,7 +104,7 @@ public class CassandraColumnEntityConverterTest {
         assertEquals(6, entity.size());
 
 
-        assertThat(entity.getColumns(), containsInAnyOrder(columns));
+        assertThat(entity.getColumns()).contains(columns);
     }
 
     @Test
@@ -283,8 +283,8 @@ public class CassandraColumnEntityConverterTest {
 
         assertEquals("address", udt.getUserType());
         assertEquals("home", udt.getName());
-        assertThat((List<Column>) udt.get(),
-                containsInAnyOrder(Column.of("city", "California"), Column.of("street", "Street")));
+        assertThat((List<Column>) udt.get())
+                .contains(Column.of("city", "California"), Column.of("street", "Street"));
 
     }
 
@@ -360,8 +360,8 @@ public class CassandraColumnEntityConverterTest {
         List<Contact> contacts = appointmentBook.getContacts();
         assertEquals("otaviojava", appointmentBook.getUser());
 
-        assertThat(contacts, containsInAnyOrder(new Contact("Poliana", "poliana"),
-                new Contact("Ada", "ada@lovelace.com")));
+        assertThat(contacts).contains(new Contact("Poliana", "poliana"),
+                new Contact("Ada", "ada@lovelace.com"));
 
 
     }

--- a/jnosql-cassandra-extension/src/test/java/org/eclipse/jnosql/mapping/cassandra/column/CassandraColumnEntityConverterTest.java
+++ b/jnosql-cassandra-extension/src/test/java/org/eclipse/jnosql/mapping/cassandra/column/CassandraColumnEntityConverterTest.java
@@ -18,7 +18,6 @@ import jakarta.nosql.TypeReference;
 import jakarta.nosql.Value;
 import jakarta.nosql.column.Column;
 import jakarta.nosql.column.ColumnEntity;
-import org.assertj.core.api.Assertions;
 import org.eclipse.jnosql.mapping.cassandra.column.model.Actor;
 import org.eclipse.jnosql.mapping.cassandra.column.model.AppointmentBook;
 import org.eclipse.jnosql.mapping.cassandra.column.model.Artist;
@@ -155,7 +154,7 @@ public class CassandraColumnEntityConverterTest {
 
 
         Column subColumn = entity.find("movie").get();
-        List<Column> columns = subColumn.get(new TypeReference<List<Column>>() {
+        List<Column> columns = subColumn.get(new TypeReference<>() {
         });
 
         assertEquals(3, columns.size());

--- a/jnosql-cassandra-extension/src/test/java/org/eclipse/jnosql/mapping/cassandra/column/DefaultCassandraTemplateTest.java
+++ b/jnosql-cassandra-extension/src/test/java/org/eclipse/jnosql/mapping/cassandra/column/DefaultCassandraTemplateTest.java
@@ -26,7 +26,6 @@ import jakarta.nosql.mapping.column.ColumnEventPersistManager;
 import jakarta.nosql.tck.test.CDIExtension;
 import org.eclipse.jnosql.communication.cassandra.column.CassandraColumnFamilyManager;
 import org.eclipse.jnosql.mapping.reflection.EntitiesMetadata;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -42,7 +41,7 @@ import java.util.stream.Stream;
 
 import static jakarta.nosql.column.ColumnQuery.select;
 import static java.util.Arrays.asList;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -101,7 +100,7 @@ public class DefaultCassandraTemplateTest {
     }
 
     @Test
-    public void shouldSaveConsntencyIterable() {
+    public void shouldSaveConsistencyIterable() {
         ColumnEntity entity = ColumnEntity.of("Person", asList(Column.of("name", "Name"), Column.of("age", 20)));
 
         ArgumentCaptor<ColumnEntity> captor = ArgumentCaptor.forClass(ColumnEntity.class);
@@ -115,7 +114,7 @@ public class DefaultCassandraTemplateTest {
         Person person = new Person();
         person.setName("Name");
         person.setAge(20);
-        assertThat(template.save(Collections.singletonList(person), level), Matchers.contains(person));
+        assertThat(template.save(Collections.singletonList(person), level)).contains(person);
         Mockito.verify(manager).save(captor.capture(), Mockito.eq(level));
         assertEquals(entity, captor.getValue());
 
@@ -159,7 +158,7 @@ public class DefaultCassandraTemplateTest {
         Person person = new Person();
         person.setName("Name");
         person.setAge(20);
-        assertThat(template.save(Collections.singletonList(person), duration, level), Matchers.contains(person));
+        assertThat(template.save(Collections.singletonList(person), duration, level)).contains(person);
         Mockito.verify(manager).save(captor.capture(), Mockito.eq(duration), Mockito.eq(level));
         assertEquals(entity, captor.getValue());
     }
@@ -187,7 +186,7 @@ public class DefaultCassandraTemplateTest {
         when(manager.select(query, level)).thenReturn(Stream.of(entity));
 
         Stream<Person> people = template.find(query, level);
-        assertThat(people.collect(Collectors.toList()), Matchers.contains(person));
+        assertThat(people.collect(Collectors.toList())).contains(person);
     }
 
     @Test
@@ -201,7 +200,7 @@ public class DefaultCassandraTemplateTest {
         when(manager.cql(cql)).thenReturn(Stream.of(entity));
 
         List<Person> people = template.<Person>cql(cql).collect(Collectors.toList());
-        assertThat(people, Matchers.contains(person));
+        assertThat(people).contains(person);
     }
     
     @Test
@@ -215,7 +214,7 @@ public class DefaultCassandraTemplateTest {
         when(manager.execute(statement)).thenReturn(Stream.of(entity));
 
         List<Person> people = template.<Person>execute(statement).collect(Collectors.toList());
-        assertThat(people, Matchers.contains(person));
+        assertThat(people).contains(person);
     }
 
 }

--- a/jnosql-elasticsearch-extension/src/test/java/org/eclipse/jnosql/mapping/elasticsearch/document/DefaultElasticsearchTemplateTest.java
+++ b/jnosql-elasticsearch-extension/src/test/java/org/eclipse/jnosql/mapping/elasticsearch/document/DefaultElasticsearchTemplateTest.java
@@ -21,7 +21,6 @@ import jakarta.nosql.mapping.document.DocumentEntityConverter;
 import jakarta.nosql.mapping.document.DocumentEventPersistManager;
 import jakarta.nosql.mapping.document.DocumentWorkflow;
 import jakarta.nosql.tck.test.CDIExtension;
-import org.assertj.core.api.Assertions;
 import org.eclipse.jnosql.communication.elasticsearch.document.ElasticsearchDocumentCollectionManager;
 import org.eclipse.jnosql.mapping.reflection.EntitiesMetadata;
 import org.elasticsearch.index.query.QueryBuilder;

--- a/jnosql-elasticsearch-extension/src/test/java/org/eclipse/jnosql/mapping/elasticsearch/document/DefaultElasticsearchTemplateTest.java
+++ b/jnosql-elasticsearch-extension/src/test/java/org/eclipse/jnosql/mapping/elasticsearch/document/DefaultElasticsearchTemplateTest.java
@@ -21,6 +21,7 @@ import jakarta.nosql.mapping.document.DocumentEntityConverter;
 import jakarta.nosql.mapping.document.DocumentEventPersistManager;
 import jakarta.nosql.mapping.document.DocumentWorkflow;
 import jakarta.nosql.tck.test.CDIExtension;
+import org.assertj.core.api.Assertions;
 import org.eclipse.jnosql.communication.elasticsearch.document.ElasticsearchDocumentCollectionManager;
 import org.eclipse.jnosql.mapping.reflection.EntitiesMetadata;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -34,10 +35,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
@@ -85,7 +85,7 @@ public class DefaultElasticsearchTemplateTest {
         QueryBuilder queryBuilder = boolQuery().filter(termQuery("name", "Ada"));
         List<Person> people = template.<Person>search(queryBuilder).collect(Collectors.toList());
 
-        assertThat(people, contains(new Person("Ada", 10)));
+        assertThat(people).contains(new Person("Ada", 10));
         Mockito.verify(manager).search(Mockito.eq(queryBuilder));
     }
 

--- a/jnosql-mongodb-extension/src/main/java/org/eclipse/jnosql/mapping/mongodb/DefaultMongoDBTemplate.java
+++ b/jnosql-mongodb-extension/src/main/java/org/eclipse/jnosql/mapping/mongodb/DefaultMongoDBTemplate.java
@@ -14,6 +14,7 @@
  */
 package org.eclipse.jnosql.mapping.mongodb;
 
+import jakarta.nosql.document.Document;
 import jakarta.nosql.document.DocumentEntity;
 import jakarta.nosql.document.DocumentQuery;
 import jakarta.nosql.mapping.Converters;
@@ -186,7 +187,7 @@ class DefaultMongoDBTemplate extends AbstractDocumentTemplate implements MongoDB
                 ExpressionQuery.class.cast(selectQuery).feed(
                         entityStream.map(
                                 documentEntity -> documentEntity.getDocuments().stream().map(
-                                        document -> document.getValue()
+                                        Document::getValue
                                 ).collect(
                                         Collectors.toList()
                                 )

--- a/jnosql-mongodb-extension/src/main/java/org/eclipse/jnosql/mapping/mongodb/criteria/CriteriaQueryUtils.java
+++ b/jnosql-mongodb-extension/src/main/java/org/eclipse/jnosql/mapping/mongodb/criteria/CriteriaQueryUtils.java
@@ -100,7 +100,7 @@ public class CriteriaQueryUtils {
                     : DocumentCondition::and;
             result = function.apply(
                     restrictions.stream().map(
-                            restriction -> computeCondition(restriction)
+                            CriteriaQueryUtils::computeCondition
                     ).toArray(
                             DocumentCondition[]::new
                     )
@@ -183,7 +183,7 @@ public class CriteriaQueryUtils {
             ExpressionQuery<X> expressionQuery = ExpressionQuery.class.cast(selectQuery);
             builder = DocumentQuery.builder(
                     expressionQuery.getExpressions().stream().map(
-                            expression -> unfold(expression)
+                            CriteriaQueryUtils::unfold
                     ).toArray(
                             String[]::new
                     )
@@ -201,9 +201,7 @@ public class CriteriaQueryUtils {
                         ).orElse(
                                 Collections.<Predicate<X>>emptyList()
                         ).stream().map(
-                                restriction -> computeCondition(
-                                        restriction
-                                )
+                                CriteriaQueryUtils::computeCondition
                         ).toArray(
                                 DocumentCondition[]::new
                         )
@@ -226,13 +224,13 @@ public class CriteriaQueryUtils {
         DocumentQuery.DocumentQueryBuilder limit = Optional.ofNullable(
                 selectQuery.getMaxResults()
         ).map(
-                maxResults -> where.limit(maxResults)
+                where::limit
         ).orElse(where);
 
         DocumentQuery.DocumentQueryBuilder skip = Optional.ofNullable(
                 selectQuery.getFirstResult()
         ).map(
-                firstResult -> limit.skip(firstResult)
+                limit::skip
         ).orElse(limit);
 
         return skip.build();

--- a/jnosql-mongodb-extension/src/main/java/org/eclipse/jnosql/mapping/mongodb/criteria/api/ExecutableQuery.java
+++ b/jnosql-mongodb-extension/src/main/java/org/eclipse/jnosql/mapping/mongodb/criteria/api/ExecutableQuery.java
@@ -42,7 +42,7 @@ public interface ExecutableQuery<T, R extends CriteriaQueryResult<T>, Q extends 
     /**
      * Feed the results specific for this kind of query.
      *
-     * @param results
+     * @param the params
      * @return the same query instance
      * @throws NullPointerException if the argument is null
      */

--- a/jnosql-mongodb-extension/src/main/java/org/eclipse/jnosql/mapping/mongodb/criteria/api/ExecutableQuery.java
+++ b/jnosql-mongodb-extension/src/main/java/org/eclipse/jnosql/mapping/mongodb/criteria/api/ExecutableQuery.java
@@ -42,7 +42,7 @@ public interface ExecutableQuery<T, R extends CriteriaQueryResult<T>, Q extends 
     /**
      * Feed the results specific for this kind of query.
      *
-     * @param the params
+     * @param results the result
      * @return the same query instance
      * @throws NullPointerException if the argument is null
      */

--- a/jnosql-mongodb-extension/src/test/java/org/eclipse/jnosql/mapping/mongodb/DocumentEntityConverterTest.java
+++ b/jnosql-mongodb-extension/src/test/java/org/eclipse/jnosql/mapping/mongodb/DocumentEntityConverterTest.java
@@ -15,7 +15,6 @@
 package org.eclipse.jnosql.mapping.mongodb;
 
 
-import io.smallrye.common.constraint.Assert;
 import jakarta.nosql.document.DocumentEntity;
 import jakarta.nosql.mapping.document.DocumentEntityConverter;
 import org.bson.types.ObjectId;

--- a/jnosql-orientdb-extension/src/test/java/org/eclipse/jnosql/mapping/orientdb/document/DefaultOrientDBTemplateTest.java
+++ b/jnosql-orientdb-extension/src/test/java/org/eclipse/jnosql/mapping/orientdb/document/DefaultOrientDBTemplateTest.java
@@ -21,7 +21,6 @@ import jakarta.nosql.mapping.Converters;
 import jakarta.nosql.mapping.document.DocumentEntityConverter;
 import jakarta.nosql.mapping.document.DocumentEventPersistManager;
 import jakarta.nosql.mapping.document.DocumentWorkflow;
-import org.assertj.core.api.Assertions;
 import org.eclipse.jnosql.mapping.reflection.EntitiesMetadata;
 import jakarta.nosql.tck.test.CDIExtension;
 import org.eclipse.jnosql.communication.orientdb.document.OrientDBDocumentCollectionManager;

--- a/jnosql-orientdb-extension/src/test/java/org/eclipse/jnosql/mapping/orientdb/document/DefaultOrientDBTemplateTest.java
+++ b/jnosql-orientdb-extension/src/test/java/org/eclipse/jnosql/mapping/orientdb/document/DefaultOrientDBTemplateTest.java
@@ -21,6 +21,7 @@ import jakarta.nosql.mapping.Converters;
 import jakarta.nosql.mapping.document.DocumentEntityConverter;
 import jakarta.nosql.mapping.document.DocumentEventPersistManager;
 import jakarta.nosql.mapping.document.DocumentWorkflow;
+import org.assertj.core.api.Assertions;
 import org.eclipse.jnosql.mapping.reflection.EntitiesMetadata;
 import jakarta.nosql.tck.test.CDIExtension;
 import org.eclipse.jnosql.communication.orientdb.document.OrientDBDocumentCollectionManager;
@@ -36,8 +37,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static jakarta.nosql.document.DocumentQuery.select;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -83,7 +83,7 @@ public class DefaultOrientDBTemplateTest {
     public void shouldFindQuery() {
         Stream<Person> people = template.sql("sql * from Person where name = ?", "Ada");
 
-        assertThat(people.collect(Collectors.toList()), contains(new Person("Ada", 10)));
+        assertThat(people.collect(Collectors.toList())).contains(new Person("Ada", 10));
         verify(manager).sql(Mockito.eq("sql * from Person where name = ?"), Mockito.eq("Ada"));
     }
 


### PR DESCRIPTION
## Main change

* Replacing assertion libraries: Hamcrest by AsseJ


## List of changes

* Update API to use Java 7 diamond
* Update API to use Lambda and method reference
* Remove the async module