### PR TITLE
Fixed POM: added required 'jakarta-data-api'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,13 @@
         </dependencies>
     </dependencyManagement>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.data</groupId>
+            <artifactId>jakarta-data-api</artifactId>
+        </dependency>
+    </dependencies>
+
     <repositories>
         <repository>
             <id>jakarta.sonatype.org-snapshot</id>


### PR DESCRIPTION
@otaviojava, I've just realized that PR #82 showed check results with failures, then I figure out that it was missing a required dependency. Please, could you review this PR ?